### PR TITLE
向pick中添加style参数，缺省为webuploader-pick，设为''时，将不自动为pick元素添加webuploader-pick ...

### DIFF
--- a/src/lib/filepicker.js
+++ b/src/lib/filepicker.js
@@ -35,7 +35,8 @@ define([
         innerHTML: null,
         multiple: true,
         accept: null,
-        name: 'file'
+        name: 'file',
+        style: 'webuploader-pick'   //pick element class attribute, default is "webuploader-pick"
     };
 
     Base.inherits( RuntimeClient, {
@@ -44,20 +45,24 @@ define([
         init: function() {
             var me = this,
                 opts = me.options,
-                button = opts.button;
+                button = opts.button,
+                style = opts.style;
 
-            button.addClass('webuploader-pick');
+            if (style)
+                button.addClass('webuploader-pick');
 
             me.on( 'all', function( type ) {
                 var files;
 
                 switch ( type ) {
                     case 'mouseenter':
-                        button.addClass('webuploader-pick-hover');
+                        if (style)
+                            button.addClass('webuploader-pick-hover');
                         break;
 
                     case 'mouseleave':
-                        button.removeClass('webuploader-pick-hover');
+                        if (style)
+                            button.removeClass('webuploader-pick-hover');
                         break;
 
                     case 'change':


### PR DESCRIPTION
...class属性，同时也不影响mouseover相关的事件，这样可以允许用户使用自已的控件样式。

使用示例为 pick:{id:'#picker', style:''}

#852