### PR TITLE
修复:flash模式下文件分片丢失问题

### DIFF
--- a/src/runtime/flash/blob.js
+++ b/src/runtime/flash/blob.js
@@ -10,7 +10,7 @@ define([
         slice: function( start, end ) {
             var blob = this.flashExec( 'Blob', 'slice', start, end );
 
-            return new Blob( blob.uid, blob );
+            return new Blob( this.getRuid(), blob );
         }
     });
 });


### PR DESCRIPTION
修复flash模式下，文件分片没有正确的设置ruid，导致缓存丢失问题