### PR TITLE
修复火狐日期转换问题

### DIFF
--- a/jekyll/js/global.js
+++ b/jekyll/js/global.js
@@ -45,7 +45,7 @@ jQuery(function() {
     }
 
     function formatDate( str ) {
-        var date = new Date( str.replace(/T/, ' ').replace(/Z/, ' UTC') );
+        var date = new Date( str.replace(/T/, ' ').replace(/Z/, '') );
 
         return date.getFullYear() + '-' +
                 formatNumber( date.getMonth() + 1 ) + '-' +


### PR DESCRIPTION
1.Chrome中var date = new Date( str.replace(/T/, ' ').replace(/Z/, ' UTC') );可以正确转换为Date对象
2.Firefox中var date = new Date( str.replace(/T/, ' ').replace(/Z/, ' UTC') );转换失败导致无法正确显示时间
