### PR TITLE
增加beforeFileQueuedCheckfileNumLimit验证,主要为了再次加载时(已存在历史文件)验证数量是否超过设置项

### DIFF
--- a/src/widgets/validator.js
+++ b/src/widgets/validator.js
@@ -70,7 +70,10 @@ define([
         }
 
         uploader.on( 'beforeFileQueued', function( file ) {
-
+                // 增加beforeFileQueuedCheckfileNumLimit验证,主要为了再次加载时(已存在历史文件)验证数量是否超过设置项
+            if (!this.trigger('beforeFileQueuedCheckfileNumLimit', file,count)) {
+                return false;
+            }
             if ( count >= max && flag ) {
                 flag = false;
                 this.trigger( 'error', 'Q_EXCEED_NUM_LIMIT', max, file );


### PR DESCRIPTION
如设置了fileNumLimit=3，第一次上传了2个文件；提交了表单。再次打开时fileNumLimit还是3。这样就不对了，此时如再传文件则一共可上传5份文件。因此加入这个验证。
实际运用时发现的这个问题。