### PR TITLE
Update runtime.js

### DIFF
--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -37,7 +37,7 @@ define([
                 return this._container;
             }
 
-            parent = $( opts.container || document.body );
+            parent = $( opts.id || document.body );
             container = $( document.createElement('div') );
 
             container.attr( 'id', 'rt_' + this.uid );


### PR DESCRIPTION
多实例获取container时，options的值被覆盖，导致container获取不对，通过id可以避免问题