### PR TITLE
修复“uploadError”事件收到的状态码错误，并增加把HTTP状态码传递给用户

### DIFF
--- a/src/runtime/html5/transport.js
+++ b/src/runtime/html5/transport.js
@@ -149,6 +149,11 @@ define([
                 me._xhr = null;
                 me._status = xhr.status;
 
+                var separator = '|', // 分隔符
+                     // 拼接的状态，在 widgets/upload.js 会有代码用到这个分隔符
+                    status = separator + xhr.status +
+                             separator + xhr.statusText;
+
                 if ( xhr.status >= 200 && xhr.status < 300 ) {
                     me._response = xhr.responseText;
                     me._headers = me._parseHeader(xhr.getAllResponseHeaders());
@@ -156,11 +161,11 @@ define([
                 } else if ( xhr.status >= 500 && xhr.status < 600 ) {
                     me._response = xhr.responseText;
                     me._headers = me._parseHeader(xhr.getAllResponseHeaders());
-                    return me.trigger( 'error', 'server-'+status );
+                    return me.trigger( 'error', 'server' + status );
                 }
 
 
-                return me.trigger( 'error', me._status ? 'http-'+status : 'abort' );
+                return me.trigger( 'error', me._status ? 'http' + status : 'abort' );
             };
 
             me._xhr = xhr;

--- a/src/widgets/upload.js
+++ b/src/widgets/upload.js
@@ -744,6 +744,13 @@ define([
 
             // 尝试重试，然后广播文件上传出错。
             tr.on( 'error', function( type, flag ) {
+                // 在 runtime/html5/transport.js 上为 type 加上了状态码，形式：type|status|text（如：http-403-Forbidden）
+                // 这里把状态码解释出来，并还原后面代码所依赖的 type 变量
+                var typeArr = type.split( '|' ), status, statusText;  
+                type = typeArr[0];
+                status = parseFloat( typeArr[1] ),
+                statusText = typeArr[2];
+
                 block.retried = block.retried || 0;
 
                 // 自动重试
@@ -761,7 +768,7 @@ define([
                     }
 
                     file.setStatus( Status.ERROR, type );
-                    owner.trigger( 'uploadError', file, type );
+                    owner.trigger( 'uploadError', file, type, status, statusText );
                     owner.trigger( 'uploadComplete', file );
                 }
             });


### PR DESCRIPTION
文件上传触发`error`事件时，类似下面代码中
```
me.trigger( 'error', 'http-'+status );
```
变量`status`在函数作用域内还没定义啊……（`+`号前后没空格，代码风格跟整体不符，是加上去加错了吧？），导致例如遇到403错误时，那么`uploadError`事件回调函数收到的第二参数就变成了`http-`（留意后面多了一个横杆）。这还会导致 widgets/upload.js 里面的自动重试相关代码不能按预期运行：
```
if ( block.chunks > 1 && ~'http,abort'.indexOf( type ) && block.retried < opts.chunkRetry ) { 
       // 这里的代码不会运行，因为type会得到类似http-的值， ~'http,abort'.indexOf( type ) 会得出假值
}
```
我查看了0.1.5版本的代码，是没有`status`这个变量的。

我在修复该处错误时顺便做了增强，因为原来在遇到400~500状态码时统一抛出了“http”的错误代码个人认为并不够具体，可能会影响开发者对错误做进一步判断，因此我补充定义了`status`变量，加入了具体的HTTP状态码，为了不影响原有的其他代码运行，在监听该错误的代码中提取了状态码后对原变量进行还原。具体查看我的注释。

对外接口中对用户的影响就是`uploadError`事件回调函数传参数增多了，参数签名：file, type, status, statusText