### PR TITLE
当子元素的父元素为hidden时，outerWidth无法获取正确的宽度。从而按钮的初始化高度为1px，无法点击。建议将初始width以及…

### DIFF
--- a/dist/webuploader.js
+++ b/dist/webuploader.js
@@ -960,8 +960,8 @@
                     position: 'absolute',
                     top: '0px',
                     left: '0px',
-                    width: '1px',
-                    height: '1px',
+                    width: '100%',
+                    height: '100%',
                     overflow: 'hidden'
                 });
     


### PR DESCRIPTION
…height改为100%