### PR TITLE
修复当元素初始化时在页面不可见时，元素高度和宽度出错的问题

### DIFF
--- a/src/lib/filepicker.js
+++ b/src/lib/filepicker.js
@@ -91,12 +91,15 @@ define([
         refresh: function() {
             var shimContainer = this.getRuntime().getContainer(),
                 button = this.options.button,
+                /*
                 width = button.outerWidth ?
                         button.outerWidth() : button.width(),
 
                 height = button.outerHeight ?
                         button.outerHeight() : button.height(),
-
+                */
+                width = button[0].offsetWidth || button.outerWidth() || button.width(),
+                height = button[0].offsetHeight || button.outerHeight() || button.height(),
                 pos = button.offset();
 
             width && height && shimContainer.css({


### PR DESCRIPTION
在使用过程中发现，当元素初始化时处于页面不可见位置时，元素的可相应区域只有1px * 1px大小，用户无法点击；
修改了在处理响应元素样式时的获取高度和宽度的问题；