### PR TITLE
火狐61.0.2下关闭文件重复上传，依然可以重复上传

### DIFF
--- a/dist/webuploader.js
+++ b/dist/webuploader.js
@@ -1676,7 +1676,7 @@
             }
     
             this.ext = ext;
-            this.lastModifiedDate = file.lastModifiedDate ||
+            this.lastModifiedDate = new Date(file.lastModified).toLocaleString() ||
                     (new Date()).toLocaleString();
     
             Blob.apply( this, arguments );


### PR DESCRIPTION
查看webuploader.js源码发现hash使用的lastModifiedDate是已经废弃的方法，
下面是火狐的api
https://developer.mozilla.org/en-US/docs/Web/API/File/lastModifiedDate;

修改源码 webuploader.js 第1679行 file.lastModifiedDate
this.lastModifiedDate = new Date(file.lastModified).toLocaleString() ||
(new Date()).toLocaleString();
在chrome 68.0.3440.106（正式版本） （64 位）和 firefox 61.0.2 (32 位)下可以校验出文件是否重复。
其它都浏览器没有测试过