### PR TITLE
Update upload.js

### DIFF
--- a/examples/image-upload/upload.js
+++ b/examples/image-upload/upload.js
@@ -146,7 +146,7 @@
             formData: {
                 uid: 123
             },
-            dnd: '#dndArea',
+            dnd: '#uploader .queueList',
             paste: '#uploader',
             swf: '../../dist/Uploader.swf',
             chunked: false,


### PR DESCRIPTION
修复 demo拖拽一次后继续拖拽不能上传问题，官方主页示例是正确的，demo文件里的示例没改。