### PR TITLE
Fix#3015 修复拖拽多个文件时fileNumLimit限制失效的BUG

### DIFF
--- a/src/widgets/queue.js
+++ b/src/widgets/queue.js
@@ -105,17 +105,18 @@ define([
         /**
          * @event fileQueued
          * @param {File} file File对象
+         * @param {int} packSize 需要加入队列文件数
          * @description 当文件被加入队列以后触发。
          * @for  Uploader
          */
 
-        _addFile: function( file ) {
+        _addFile: function( file, packSize ) {
             var me = this;
 
             file = me._wrapFile( file );
 
             // 不过类型判断允许不允许，先派送 `beforeFileQueued`
-            if ( !me.owner.trigger( 'beforeFileQueued', file ) ) {
+            if ( !me.owner.trigger( 'beforeFileQueued', file, packSize ) ) {
                 return;
             }
 
@@ -164,8 +165,9 @@ define([
                 files = [ files ];
             }
 
-            files = $.map( files, function( file ) {
-                return me._addFile( file );
+            var packSize = files.length;
+            files = $.map( files, function( file, i ) {
+                return me._addFile( file, packSize - i );
             });
 			
 			if ( files.length ) {

--- a/src/widgets/validator.js
+++ b/src/widgets/validator.js
@@ -69,12 +69,13 @@ define([
             return;
         }
 
-        uploader.on( 'beforeFileQueued', function( file ) {
+        uploader.on( 'beforeFileQueued', function( file, packSize ) {
                 // 增加beforeFileQueuedCheckfileNumLimit验证,主要为了再次加载时(已存在历史文件)验证数量是否超过设置项
             if (!this.trigger('beforeFileQueuedCheckfileNumLimit', file,count)) {
                 return false;
             }
-            if ( count >= max && flag ) {
+            packSize = packSize || 1;
+            if ( count + packSize > max && flag ) {
                 flag = false;
                 this.trigger( 'error', 'Q_EXCEED_NUM_LIMIT', max, file );
                 setTimeout(function() {
@@ -82,7 +83,7 @@ define([
                 }, 1 );
             }
 
-            return count >= max ? false : true;
+            return count + packSize <= max;
         });
 
         uploader.on( 'fileQueued', function() {


### PR DESCRIPTION
RT 拖拽或选择多个文件超出限制时取末尾N个文件并产生Q_EXCEED_NUM_LIMIT错误