### PR TITLE
修复因DragAndDrop、FilePaste重用导致的多实例时上述功能无法使用的问题

### DIFF
--- a/src/lib/dnd.js
+++ b/src/lib/dnd.js
@@ -5,7 +5,7 @@ define([
     '../base',
     '../mediator',
     '../runtime/client'
-], function( Base, Mediator, RuntimeClent ) {
+], function( Base, Mediator, RuntimeClient ) {
 
     var $ = Base.$;
 
@@ -18,7 +18,7 @@ define([
             return;
         }
 
-        RuntimeClent.call( this, 'DragAndDrop' );
+        RuntimeClient.call( this, 'DragAndDrop', true );//与FilePicker一样为一种文件选择器，不能重用
     }
 
     DragAndDrop.options = {
@@ -26,7 +26,7 @@ define([
         disableGlobalDnd: false
     };
 
-    Base.inherits( RuntimeClent, {
+    Base.inherits( RuntimeClient, {
         constructor: DragAndDrop,
 
         init: function() {

--- a/src/lib/filepaste.js
+++ b/src/lib/filepaste.js
@@ -5,17 +5,17 @@ define([
     '../base',
     '../mediator',
     '../runtime/client'
-], function( Base, Mediator, RuntimeClent ) {
+], function( Base, Mediator, RuntimeClient ) {
 
     var $ = Base.$;
 
     function FilePaste( opts ) {
         opts = this.options = $.extend({}, opts );
         opts.container = $( opts.container || document.body );
-        RuntimeClent.call( this, 'FilePaste' );
+        RuntimeClient.call( this, 'FilePaste', true );//与FilePicker一样为一种文件选择器，不能重用
     }
 
-    Base.inherits( RuntimeClent, {
+    Base.inherits( RuntimeClient, {
         constructor: FilePaste,
 
         init: function() {


### PR DESCRIPTION
修复因DragAndDrop、FilePaste重用导致的多实例时上述功能无法使用的问题。

无法使用的原因是DragAndDrop、FilePaste和FilePicker一样为一种文件选择器，是不能重用的。

另外同时修复了两个文件中RuntimeClient的Typo。

反映类似问题的部分Issue:
https://github.com/fex-team/webuploader/issues/508
https://github.com/fex-team/webuploader/issues/1438
https://github.com/fex-team/webuploader/issues/1956